### PR TITLE
updates for upstream project

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save @vuedoc/parser
 - `encoding` (*optional*) `default: utf8`
 - `ignoreName` (*optional*) `default: false` Set `true` to ignore the component name in the result
 - `ignoreDescription` (*optional*) `default: false` Set `true` to ignore the component description in the result
-- `methodsDefaultPrivate` (*optional*) `default: false` Set `true` to treat methods as `@private` unless otherwise specified
+- `defaultMethodVisibility` (*optional*) `default: DEFAULT_VISIBILITY`. Can be set to `private`, `public`, or `protected` to override global `DEFAULT_VISIBILITY` for component methods.
 
 ## Usage
 ```js

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,7 +40,9 @@ const getCommentVisibility = (text, defaultVisibility) => {
   return defaultVisibility
 }
 
-const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY) => {
+const parseComment = (text, defaultVisibility) => {
+  defaultVisibility = defaultVisibility || DEFAULT_VISIBILITY
+
   const parsedComment = {
     visibility: getCommentVisibility(text, defaultVisibility),
     describeModel: hasModelDecoration(text),
@@ -57,7 +59,9 @@ const parseComment = (text, defaultVisibility = DEFAULT_VISIBILITY) => {
   return parsedComment
 }
 
-const getComment = (property, defaultVisibility = DEFAULT_VISIBILITY) => {
+const getComment = (property, defaultVisibility) => {
+  defaultVisibility = defaultVisibility || DEFAULT_VISIBILITY
+
   let lastComment = null
 
   if (property.leadingComments) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -210,7 +210,7 @@ class Parser extends EventEmitter {
     this.template = options.source.template
     this.filename = options.filename
     this.eventsEmmited = {}
-    this.methodsDefaultPrivate = options.methodsDefaultPrivate
+    this.defaultMethodVisibility = options.defaultMethodVisibility
   }
 
   extractProperties (property) {
@@ -218,8 +218,8 @@ class Parser extends EventEmitter {
       case 'ObjectExpression':
         property.value.properties.forEach((p) => {
           let defaultVisibility = DEFAULT_VISIBILITY
-          if (property.key.name === 'methods' && this.methodsDefaultPrivate) {
-            defaultVisibility = 'private'
+          if (property.key.name === 'methods' && this.defaultMethodVisibility) {
+            defaultVisibility = this.defaultMethodVisibility
           }
           const entry = getComment(p, defaultVisibility)
 

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -318,7 +318,7 @@ describe('component.methods_visibility_private', () => {
   parser.parse({
     filename: f('checkboxMethods.vue'),
     encoding: 'utf8',
-    methodsDefaultPrivate: true
+    defaultMethodVisibility: 'private'
   })
     .then((_component) => (component = _component))
     .catch((err) => {


### PR DESCRIPTION

re: https://github.com/vuedoc/parser/pull/2

* Change boolean `methodsDefaultPrivate` to string `defaultMethodVisibility` option. We'll have to update our code here: https://github.com/learningequality/kolibri/blob/release-v0.6.x/kolibri/plugins/style_guide/vue-doc-loader.js#L16
* remove use of default values for function parameters